### PR TITLE
Price processor

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -24,3 +24,8 @@ Breadcrumbs
    :undoc-members:
 
 .. autofunction:: zyte_parsers.extract_breadcrumbs
+
+Price
+-----
+
+.. autofunction:: zyte_parsers.extract_price

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "html-text",
     "lxml",
     "parsel",
+    "price-parser>=0.3.4",
     "w3lib",
 ]
 dynamic = ["version"]

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -2,18 +2,20 @@ from decimal import Decimal
 
 import pytest
 from lxml.html import fromstring
+from price_parser import Price
 
 from zyte_parsers.price import extract_price
 
 
 @pytest.mark.parametrize(
-    ["html", "expected"],
+    ["html", "currency_hint", "expected"],
     [
-        ("<p></p>", None),
-        ("<p>23.5</p>", Decimal(23.5)),
-        ("<p>$23.5</p>", Decimal(23.5)),
+        ("<p></p>", None, Price(None, None, None)),
+        ("<p>23.5</p>", None, Price(Decimal(23.5), None, "23.5")),
+        ("<p>$23.5</p>", None, Price(Decimal(23.5), "$", "23.5")),
+        ("<p>23.5</p>", "USD", Price(Decimal(23.5), "USD", "23.5")),
     ],
 )
-def test_price_simple(html, expected):
-    result = extract_price(fromstring(html))
+def test_price_simple(html, currency_hint, expected):
+    result = extract_price(fromstring(html), currency_hint=currency_hint)
     assert result == expected

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -1,0 +1,19 @@
+from decimal import Decimal
+
+import pytest
+from lxml.html import fromstring
+
+from zyte_parsers.price import extract_price
+
+
+@pytest.mark.parametrize(
+    ["html", "expected"],
+    [
+        ("<p></p>", None),
+        ("<p>23.5</p>", Decimal(23.5)),
+        ("<p>$23.5</p>", Decimal(23.5)),
+    ],
+)
+def test_price_simple(html, expected):
+    result = extract_price(fromstring(html))
+    assert result == expected

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -16,6 +16,8 @@ from zyte_parsers.price import extract_price
         ("<p>23.5</p>", "USD", Price(Decimal(23.5), "USD", "23.5")),
         ("<p>$23.5</p>", "USD", Price(Decimal(23.5), "$", "23.5")),
         ("<p>£23.5</p>", "USD", Price(Decimal(23.5), "£", "23.5")),
+        ("<p>23.5</p>", "<b>USD</b>", Price(Decimal(23.5), "USD", "23.5")),
+        ("<p>23.5</p>", fromstring("<b>USD</b>"), Price(Decimal(23.5), "USD", "23.5")),
     ],
 )
 def test_price_simple(html, currency_hint, expected):

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -14,6 +14,8 @@ from zyte_parsers.price import extract_price
         ("<p>23.5</p>", None, Price(Decimal(23.5), None, "23.5")),
         ("<p>$23.5</p>", None, Price(Decimal(23.5), "$", "23.5")),
         ("<p>23.5</p>", "USD", Price(Decimal(23.5), "USD", "23.5")),
+        ("<p>$23.5</p>", "USD", Price(Decimal(23.5), "$", "23.5")),
+        ("<p>£23.5</p>", "USD", Price(Decimal(23.5), "£", "23.5")),
     ],
 )
 def test_price_simple(html, currency_hint, expected):

--- a/zyte_parsers/__init__.py
+++ b/zyte_parsers/__init__.py
@@ -3,3 +3,4 @@ __version__ = "0.2.0"
 from .api import SelectorOrElement
 from .brand import extract_brand_name
 from .breadcrumbs import Breadcrumb, extract_breadcrumbs
+from .price import extract_price

--- a/zyte_parsers/price.py
+++ b/zyte_parsers/price.py
@@ -1,0 +1,18 @@
+from decimal import Decimal
+from typing import Optional
+
+from price_parser import Price
+
+from zyte_parsers import SelectorOrElement
+from zyte_parsers.utils import extract_text
+
+
+def extract_price(node: SelectorOrElement) -> Optional[Decimal]:
+    """Extract a price value from a node that contains it.
+
+    :param node: Node including the price text.
+    :return: The price value or None.
+    """
+    text = extract_text(node)
+    price_parsed = Price.fromstring(text)
+    return price_parsed.amount

--- a/zyte_parsers/price.py
+++ b/zyte_parsers/price.py
@@ -1,4 +1,3 @@
-from decimal import Decimal
 from typing import Optional
 
 from price_parser import Price
@@ -7,12 +6,14 @@ from zyte_parsers import SelectorOrElement
 from zyte_parsers.utils import extract_text
 
 
-def extract_price(node: SelectorOrElement) -> Optional[Decimal]:
+def extract_price(
+    node: SelectorOrElement, *, currency_hint: Optional[str] = None
+) -> Price:
     """Extract a price value from a node that contains it.
 
     :param node: Node including the price text.
-    :return: The price value or None.
+    :param currency_hint: Currency hint for ``price-parser``.
+    :return: The price value as a ``price_parser.Price`` object.
     """
     text = extract_text(node)
-    price_parsed = Price.fromstring(text)
-    return price_parsed.amount
+    return Price.fromstring(text, currency_hint=currency_hint)

--- a/zyte_parsers/price.py
+++ b/zyte_parsers/price.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Union
 
 from price_parser import Price
 
@@ -7,13 +7,20 @@ from zyte_parsers.utils import extract_text
 
 
 def extract_price(
-    node: SelectorOrElement, *, currency_hint: Optional[str] = None
+    node: SelectorOrElement,
+    *,
+    currency_hint: Union[SelectorOrElement, str, None] = None,
 ) -> Price:
     """Extract a price value from a node that contains it.
 
     :param node: Node including the price text.
-    :param currency_hint: Currency hint for ``price-parser``.
+    :param currency_hint: A string or a node that can contain currency. It will
+        be passed as a hint to ``price-parser``. If currency is present in the
+        price string, it could be preferred over the value extracted from
+        ``currency_hint``.
     :return: The price value as a ``price_parser.Price`` object.
     """
     text = extract_text(node)
+    if currency_hint is not None and not isinstance(currency_hint, str):
+        currency_hint = extract_text(currency_hint)
     return Price.fromstring(text, currency_hint=currency_hint)


### PR DESCRIPTION
This is probably the simplest implementation, there are several other things that we coukd implement here, implement in zyte-common-items or leave out:

1. Return a string instead of a number. Probably even provide both functions.
2. Return a float instead of a Decimal.
3. Return not just the price but also the currency.
4. Take an optional currency hint and pass it to `Price.fromstring()` as `currency_hint`. Implies (3).

There are some problems with returning price and currency from the same function though, as in zyte-common-items those are two separate fields and there is also a third field (currency as an ISO code) that it won't be able to get from here.